### PR TITLE
feat: added engine specifications to package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,10 @@
         "typescript": "^4.8.3",
         "vite": "^3.1.0",
         "vite-plugin-pwa": "^0.13.0"
+      },
+      "engines": {
+        "node": ">=16.17.0",
+        "npm": ">=8.19.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -49,5 +49,9 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
+  },
+  "engines": {
+    "node": ">=16.17.0",
+    "npm": ">=8.19.1"
   }
 }


### PR DESCRIPTION
now npm will throw errors for node versions less than v16.17.0 and npm versions less than v8.19.1